### PR TITLE
Do not import 'k6' js module just to reuse error

### DIFF
--- a/py/builtin/check/check.go
+++ b/py/builtin/check/check.go
@@ -3,19 +3,19 @@
 package check
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/grafana/xk6-python/py/builtin/helpers"
 	"github.com/sirupsen/logrus"
 	"go.k6.io/k6/js/modules"
-	"go.k6.io/k6/js/modules/k6"
 	"go.k6.io/k6/metrics"
 	"go.starlark.net/starlark"
 )
 
 type module struct {
-	vu modules.VU
+	vu     modules.VU
 	logger logrus.FieldLogger
 }
 
@@ -31,7 +31,7 @@ func Load(_ string, _ *starlark.Thread, vu modules.VU) (starlark.StringDict, err
 func (mod *module) check(th *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	state := mod.vu.State()
 	if state == nil {
-		return starlark.False, k6.ErrCheckInInitContext
+		return starlark.False, errors.New("Using group() in hte init context is not support")
 	}
 
 	// validate the arguments and get useful objects
@@ -73,7 +73,7 @@ func (mod *module) check(th *starlark.Thread, _ *starlark.Builtin, args starlark
 		if err == nil {
 			mod.logger.Debugf("Function returned: %s", result)
 			resultBool := starlark.Bool(result.Truth())
-			if !resultBool  {
+			if !resultBool {
 				thisItemOk = false
 			}
 		} else {
@@ -93,7 +93,7 @@ func (mod *module) check(th *starlark.Thread, _ *starlark.Builtin, args starlark
 		sample := metrics.Sample{
 			TimeSeries: metrics.TimeSeries{
 				Metric: state.BuiltinMetrics.Checks,
-				Tags: tags,
+				Tags:   tags,
 			},
 			Time: currentTime,
 		}

--- a/py/builtin/group/group.go
+++ b/py/builtin/group/group.go
@@ -3,13 +3,13 @@
 package group
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/grafana/xk6-python/py/builtin/helpers"
 	"github.com/sirupsen/logrus"
 	"go.k6.io/k6/js/modules"
-	"go.k6.io/k6/js/modules/k6"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/metrics"
 	"go.starlark.net/starlark"
@@ -32,7 +32,7 @@ func Load(_ string, _ *starlark.Thread, vu modules.VU) (starlark.StringDict, err
 func (mod *module) group(th *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	state := mod.vu.State()
 	if state == nil {
-		return starlark.False, k6.ErrCheckInInitContext
+		return starlark.False, errors.New("Using group() in hte init context is not support")
 	}
 
 	// validate the arguments and get useful objects


### PR DESCRIPTION
As part of preparations for 1.0.0 we are reducing the public API of k6 especialy in cases where it doesn't make sense

To this end https://github.com/grafana/k6/pull/4676 was opened in which the k6 js module code is being moved to `internal`.

This project is using this code in order to get an error. 

Also in this case the original error was not correct as it would say `group()` in on the of the places.

Also gofmt did some formatting that I left.

Please merge this before v1.0.0 of k6 is released so that the extension doesn't stop working. You might also need to tag a release after that.